### PR TITLE
fix: input 0 processing

### DIFF
--- a/src/script/assembly_x86/torre_hanoi.asm
+++ b/src/script/assembly_x86/torre_hanoi.asm
@@ -180,7 +180,7 @@ avaliar_entrada: ; Verificar se a entrada é um número de até 2 algarismos mai
     quantidade_caracteres_valida: ; Quantidade de caracteres válida
     
     mov al, entrada[0] ; Move o primeiro caractere da entrada para o registrador al
-    cmp al, 0x30 ; Compara este caractere com o valor na tabela ASCII do número 0(decimal) em formato de string 
+    cmp al, 0x31 ; Compara este caractere com o valor na tabela ASCII do número 1(decimal) em formato de string 
     jl invalido ; Se for menor, então significa que o que o usuário digitou não é um número, a entrada então será considerada inválida
     cmp al, 0x39 ; Compara este caractere com o valor na tabela ASCII do número 9(decimal) em formato de string 
     jg invalido ; Se for maior, então significa que o que o usuário digitou não é um número, a entrada então será considerada inválida


### PR DESCRIPTION
O primeiro caractere de entrada agora não pode ser a string "0", porque o valor 0 inteiro causa loop infinito no algaritmo, então foi alterada a linha que trata do primeiro caractere e avalia se ele é válido ou inválido. Como consequência, o código tratará entradas como "03" ou "05" como inválidas, porém invalidará entradas como "0" e "00" que causam loop infinito.